### PR TITLE
Add RPM support.

### DIFF
--- a/licorice/config.py
+++ b/licorice/config.py
@@ -3,4 +3,4 @@ DEFINITIONS_DIR = 'data/definitions'
 METADATA_DIR    = 'data/metadata'
 LINE_LIMIT      = 1000
 
-ARCHIVE_EXT     = { '.bz2', '.gz', '.tar', '.jar', '.war', '.zip', '.gem', '.xz' }
+ARCHIVE_EXT     = { '.bz2', '.gz', '.tar', '.jar', '.war', '.zip', '.gem', '.xz', '.rpm' }

--- a/licorice/loaders.py
+++ b/licorice/loaders.py
@@ -77,21 +77,29 @@ class ProjectLoader:
         working_directory = os.getcwd()
         os.chdir(tmpdir)
 
+        archive_ext = os.path.splitext(path)[1]
+
         # Extract file based on the extension
         try:
-            cmdline = {
-                '.bz2' : ["tar", "xjf", path],
-                '.gz'  : ["tar", "xzf", path],
-                '.xz'  : ["tar", "xJf", path],
-                '.jar' : ["unzip", "-q", path],
-                '.tar' : ["tar", "xf", path],
-                '.rar' : ["unrar", "e", path],
-                '.war' : ["unzip", "-q", path],
-                '.zip' : ["unzip", "-q", path],
-                '.gem' : ["gem", "unpack", path],
-            }[os.path.splitext(path)[1]]
-            logger.debug('Unpacking: {}'.format(cmdline))
-            subprocess.call(cmdline)
+            if archive_ext in ['.rpm']:
+               logger.debug('Unpacking: {}'.format(path))
+               rpm2cpio = subprocess.Popen(('rpm2cpio', path), stdout=subprocess.PIPE)
+               output = subprocess.check_output(('cpio', '-idmv'), stdin=rpm2cpio.stdout)
+               rpm2cpio.wait()
+            else:
+               cmdline = {
+                   '.bz2' : ["tar", "xjf", path],
+                   '.gz'  : ["tar", "xzf", path],
+                   '.xz'  : ["tar", "xJf", path],
+                   '.jar' : ["unzip", "-q", path],
+                   '.tar' : ["tar", "xf", path],
+                   '.rar' : ["unrar", "e", path],
+                   '.war' : ["unzip", "-q", path],
+                   '.zip' : ["unzip", "-q", path],
+                   '.gem' : ["gem", "unpack", path],
+               }[archive_ext]
+               logger.debug('Unpacking: {}'.format(cmdline))
+               subprocess.call(cmdline)
         except:
             result = FileInProject(path)
             result.error_unpacking = True


### PR DESCRIPTION
This allows to extract files from RPM and check the licenses. Admittedly, it makes the code akward, but I have not idea how to make it better. I unsuccessfully tried something like  ```subprocess.call(['rpm2cpio', path, '|', 'cpio', '-idmv'], shell=True)``` ...